### PR TITLE
Managed external objects

### DIFF
--- a/ext/v8/external.cc
+++ b/ext/v8/external.cc
@@ -1,0 +1,37 @@
+#include "rr.h"
+#include "external.h"
+
+namespace rr {
+  void External::Init() {
+    ClassBuilder("External").
+      defineSingletonMethod("New", &New).
+
+      defineMethod("Value", &Value).
+
+      store(&Class);
+  }
+
+  VALUE External::New(VALUE self, VALUE r_isolate, VALUE object) {
+    Isolate isolate(r_isolate);
+    isolate.retainObject(object);
+
+    Locker lock(isolate);
+
+    Container* container = new Container(object);
+    v8::Local<v8::External> external(v8::External::New(isolate, (void*)container));
+
+    v8::Global<v8::External>* global(new v8::Global<v8::External>(isolate, external));
+    container->global = global;
+
+    global->SetWeak<Container>(container, &release, v8::WeakCallbackType::kParameter);
+
+    return External(isolate, external);
+  }
+
+  VALUE External::Value(VALUE self) {
+    External external(self);
+    Locker lock(external);
+    Container* container((Container*)external->Value());
+    return container->object;
+  }
+}

--- a/ext/v8/external.cc
+++ b/ext/v8/external.cc
@@ -13,17 +13,23 @@ namespace rr {
 
   VALUE External::New(VALUE self, VALUE r_isolate, VALUE object) {
     Isolate isolate(r_isolate);
+
+    // as long as this external is alive within JavaScript, it should not be
+    // garbage collected by Ruby.
     isolate.retainObject(object);
 
     Locker lock(isolate);
 
+    // create the external.
     Container* container = new Container(object);
     v8::Local<v8::External> external(v8::External::New(isolate, (void*)container));
 
+    // next, we create a weak reference to this external so that we can be
+    // notified when V8 is done with it. At that point, we can let Ruby know
+    // that this external is done with it.
     v8::Global<v8::External>* global(new v8::Global<v8::External>(isolate, external));
-    container->global = global;
-
     global->SetWeak<Container>(container, &release, v8::WeakCallbackType::kParameter);
+    container->global = global;
 
     return External(isolate, external);
   }

--- a/ext/v8/external.h
+++ b/ext/v8/external.h
@@ -21,6 +21,14 @@ namespace rr {
       VALUE object;
     };
 
+    /**
+     * Implements a v8::WeakCallbackInfo<Container>::Callback with all
+     * of its idiosyncracies. It happens in two passes. In the first
+     * pass, you are required to only reset the weak reference. In the
+     * second pass, you can actually do your cleanup. In this case, we
+     * schedule the referenced Ruby object to be released in the next
+     * Ruby gc pass.
+     */
     static void release(const v8::WeakCallbackInfo<Container>& info) {
       Container* container(info.GetParameter());
       if (info.IsFirstPass()) {

--- a/ext/v8/external.h
+++ b/ext/v8/external.h
@@ -1,0 +1,38 @@
+// -*- mode: c++ -*-
+#ifndef EXTERNAL_H
+#define EXTERNAL_H
+
+namespace rr {
+  class External : Ref<v8::External> {
+  public:
+
+    static void Init();
+    static VALUE New(VALUE self, VALUE isolate, VALUE object);
+    static VALUE Value(VALUE self);
+
+    inline External(VALUE value) : Ref<v8::External>(value) {}
+    inline External(v8::Isolate* isolate, v8::Handle<v8::External> handle) :
+      Ref<v8::External>(isolate, handle) {}
+
+    struct Container {
+      Container(VALUE v) : object(v) {}
+
+      v8::Global<v8::External>* global;
+      VALUE object;
+    };
+
+    static void release(const v8::WeakCallbackInfo<Container>& info) {
+      Container* container(info.GetParameter());
+      if (info.IsFirstPass()) {
+        container->global->Reset();
+        info.SetSecondPassCallback(&release);
+      } else {
+        Isolate isolate(info.GetIsolate());
+        isolate.scheduleReleaseObject(container->object);
+        delete container;
+      }
+    }
+  };
+}
+
+#endif /* EXTERNAL_H */

--- a/ext/v8/init.cc
+++ b/ext/v8/init.cc
@@ -20,6 +20,7 @@ extern "C" {
     Function::Init();
     Script::Init();
     Array::Init();
+    External::Init();
 
     // Accessor::Init();
     // Invocation::Init();

--- a/ext/v8/isolate.cc
+++ b/ext/v8/isolate.cc
@@ -5,6 +5,7 @@
 namespace rr {
 
   void Isolate::Init() {
+    rb_eval_string("require 'v8/retained_objects'");
     ClassBuilder("Isolate").
       defineSingletonMethod("New", &New).
 
@@ -17,11 +18,16 @@ namespace rr {
 
   VALUE Isolate::New(VALUE self) {
     Isolate::IsolateData* data = new IsolateData();
+    VALUE rb_cRetainedObjects = rb_eval_string("V8::RetainedObjects");
+    data->retained_objects = rb_funcall(rb_cRetainedObjects, rb_intern("new"), 0);
+
     v8::Isolate::CreateParams create_params;
     create_params.array_buffer_allocator = &data->array_buffer_allocator;
+
     Isolate isolate(v8::Isolate::New(create_params));
-    isolate->SetData(0, new IsolateData());
+    isolate->SetData(0, data);
     isolate->AddGCPrologueCallback(&clearReferences);
+
     return isolate;
   }
 

--- a/ext/v8/isolate.h
+++ b/ext/v8/isolate.h
@@ -57,7 +57,7 @@ namespace rr {
      */
     template <class T>
     inline void scheduleDelete(v8::Persistent<T>* cell) {
-      data()->queue.enqueue((v8::Persistent<void>*)cell);
+      data()->v8_release_queue.enqueue((v8::Persistent<void>*)cell);
     }
 
     inline void retainObject(VALUE object) {
@@ -90,7 +90,7 @@ namespace rr {
     static void clearReferences(v8::Isolate* i, v8::GCType type, v8::GCCallbackFlags flags) {
       Isolate isolate(i);
       v8::Persistent<void>* cell;
-      while (isolate.data()->queue.try_dequeue(cell)) {
+      while (isolate.data()->v8_release_queue.try_dequeue(cell)) {
         cell->Reset();
         delete cell;
       }
@@ -139,7 +139,7 @@ namespace rr {
        * finished with an object it will be enqueued here so that it
        * can be released by the v8 garbarge collector later.
        */
-      ConcurrentQueue<v8::Persistent<void>*> queue;
+      ConcurrentQueue<v8::Persistent<void>*> v8_release_queue;
 
       /**
        * Queue to hold

--- a/ext/v8/isolate.h
+++ b/ext/v8/isolate.h
@@ -69,14 +69,14 @@ namespace rr {
     }
 
     inline void scheduleReleaseObject(VALUE object) {
-      data()->release_queue.enqueue(object);
+      data()->rb_release_queue.enqueue(object);
     }
 
     static void releaseAndMarkRetainedObjects(v8::Isolate* isolate_) {
       Isolate isolate(isolate_);
       IsolateData* data = isolate.data();
       VALUE object;
-      while (data->release_queue.try_dequeue(object)) {
+      while (data->rb_release_queue.try_dequeue(object)) {
         isolate.releaseObject(object);
       }
       rb_gc_mark(data->retained_objects);
@@ -144,7 +144,7 @@ namespace rr {
       /**
        * Queue to hold
        */
-      ConcurrentQueue<VALUE> release_queue;
+      ConcurrentQueue<VALUE> rb_release_queue;
     };
   };
 }

--- a/ext/v8/isolate.h
+++ b/ext/v8/isolate.h
@@ -170,7 +170,10 @@ namespace rr {
       ConcurrentQueue<v8::Persistent<void>*> v8_release_queue;
 
       /**
-       * Queue to hold
+       * Ruby objects that had been retained by this isolate, but that
+       * are eligible for release. Generally, an object ends up in a
+       * queue when the v8 object that had referenced it no longer
+       * needs it.
        */
       ConcurrentQueue<VALUE> rb_release_queue;
     };

--- a/ext/v8/ref.h
+++ b/ext/v8/ref.h
@@ -75,6 +75,10 @@ namespace rr {
       return isolate;
     }
 
+    inline operator v8::Isolate*() const {
+      return isolate;
+    }
+
     static void destroy(Holder* holder) {
       delete holder;
     }

--- a/ext/v8/rr.h
+++ b/ext/v8/rr.h
@@ -37,6 +37,7 @@ inline VALUE not_implemented(const char* message) {
 #include "object.h"
 #include "array.h"
 #include "primitive.h"
+#include "external.h"
 // This one is named v8_string to avoid name collisions with C's string.h
 #include "rr_string.h"
 

--- a/lib/v8/retained_objects.rb
+++ b/lib/v8/retained_objects.rb
@@ -1,0 +1,29 @@
+module V8
+  class RetainedObjects
+    def initialize
+      @counts = {}
+    end
+
+    def add(object)
+      if @counts[object]
+        @counts[object] += 1
+      else
+        @counts[object] = 1
+      end
+    end
+
+    def remove(object)
+      if count = @counts[object]
+        if count <= 1
+          @counts.delete object
+        else
+          @counts[object] -= 1
+        end
+      end
+    end
+
+    def retaining?(object)
+      !!@counts[object]
+    end
+  end
+end

--- a/spec/c/external_spec.rb
+++ b/spec/c/external_spec.rb
@@ -1,0 +1,23 @@
+require 'c_spec_helper'
+
+describe V8::C::External do
+  let(:isolate) { V8::C::Isolate::New() }
+  let(:value) { @external::Value() }
+  around { |example| V8::C::HandleScope(isolate) { example.run } }
+
+  before do
+    Object.new.tap do |object|
+      @object_id = object.object_id
+      @external = V8::C::External::New(isolate, object)
+    end
+  end
+
+  it "exists" do
+    expect(@external).to be
+  end
+
+  it "can retrieve the ruby object out from V8 land" do
+    expect(value).to be
+    expect(value.object_id).to eql @object_id
+  end
+end

--- a/spec/v8/retained_objects_spec.rb
+++ b/spec/v8/retained_objects_spec.rb
@@ -1,0 +1,47 @@
+require 'v8/retained_objects'
+
+describe V8::RetainedObjects do
+  let(:object) { Object.new }
+  let(:objects) { V8::RetainedObjects.new }
+
+  it "knows that something isn't retained" do
+    expect(objects).not_to be_retaining object
+  end
+
+  describe "adding a reference to an object" do
+    before do
+      objects.add(object)
+    end
+
+    it "is now retained" do
+      expect(objects).to be_retaining object
+    end
+
+    describe "removing the reference" do
+      before do
+        objects.remove(object)
+      end
+      it "is no longer retained" do
+        expect(objects).to_not be_retaining object
+      end
+    end
+    describe "adding another reference and then removing" do
+      before do
+        objects.add(object)
+        objects.remove(object)
+      end
+      it "is still retained" do
+        expect(objects).to be_retaining object
+      end
+
+      describe "removing one more time" do
+        before do
+          objects.remove(object)
+        end
+        it "is no longer retained" do
+          expect(objects).to_not be_retaining object
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds support for `V8::C::External`. When you create one of these objects, you pass an object to it. This object will be retained until the `V8::C::External` is garbage collected by V8.
