### PR TITLE
implement JavaScript numeric types

### DIFF
--- a/ext/v8/array.cc
+++ b/ext/v8/array.cc
@@ -27,14 +27,14 @@ namespace rr {
     Array array(self);
     Locker lock(array.getIsolate());
 
-    return UInt32(array->Length());
+    return Uint32_t(array->Length());
   }
 
   VALUE Array::CloneElementAt(VALUE self, VALUE index) {
     Array array(self);
     Locker lock(array.getIsolate());
 
-    return Object(array.getIsolate(), array->CloneElementAt(UInt32(index)));
+    return Object(array.getIsolate(), array->CloneElementAt(Uint32_t(index)));
   }
 
 }

--- a/ext/v8/init.cc
+++ b/ext/v8/init.cc
@@ -16,6 +16,7 @@ extern "C" {
     Value::Init();
     Object::Init();
     Primitive::Init();
+    Number::Init();
     String::Init();
     Function::Init();
     Script::Init();

--- a/ext/v8/number.cc
+++ b/ext/v8/number.cc
@@ -1,0 +1,69 @@
+#include "rr.h"
+
+namespace rr {
+  void Number::Init() {
+    ClassBuilder("Number", Primitive::Class).
+
+      defineSingletonMethod("New", [] (VALUE self, VALUE r_isolate, VALUE value) -> VALUE {
+          Isolate isolate(r_isolate);
+          Locker lock(isolate);
+
+          return Number(isolate, NUM2DBL(value));
+        }).
+
+      defineMethod("Value", [] (VALUE self) -> VALUE {
+          Number number(self);
+          Locker lock(number);
+
+          return DBL2NUM(number->Value());
+        }).
+
+      store(&Class);
+
+    ClassBuilder("Integer", Number::Class).
+
+      defineSingletonMethod("New", [] (VALUE self, VALUE r_isolate, VALUE value) -> VALUE {
+          Isolate isolate(r_isolate);
+          Locker lock(isolate);
+
+          auto integer = v8::Integer::New(isolate, NUM2INT(value));
+          return Value::handleToRubyObject(isolate, integer);
+        }).
+
+      defineSingletonMethod("NewFromUnsigned", [] (VALUE self, VALUE r_isolate, VALUE value) -> VALUE {
+          Isolate isolate(r_isolate);
+          Locker lock(isolate);
+
+          auto uint = v8::Integer::NewFromUnsigned(isolate, NUM2UINT(value));
+          return Value::handleToRubyObject(isolate, uint);
+        }).
+
+      defineMethod("Value", [] (VALUE self) -> VALUE {
+          Integer integer(self);
+          Locker lock(integer);
+
+          return INT2NUM(integer->Value());
+        }).
+
+      store(&Integer::Class);
+
+    ClassBuilder("Int32", Integer::Class).
+
+      defineMethod("Value", [] (VALUE self) -> VALUE {
+          Int32 int32(self);
+          Locker lock(int32);
+
+          return INT2NUM(int32->Value());
+        }).
+      store(&Int32::Class);
+
+    ClassBuilder("Uint32", Integer::Class).
+      defineMethod("Value", [] (VALUE self) -> VALUE {
+          Uint32 uint32(self);
+          Locker lock(uint32);
+
+          return UINT2NUM(uint32->Value());
+        }).
+      store(&Uint32::Class);
+  }
+}

--- a/ext/v8/number.h
+++ b/ext/v8/number.h
@@ -1,0 +1,46 @@
+// -*- mode: c++ -*-
+#ifndef NUMBER_H
+#define NUMBER_H
+
+namespace rr {
+  class Number : public Ref<v8::Number> {
+  public:
+    Number(v8::Isolate* isolate, double value) :
+      Ref<v8::Number>(isolate, v8::Number::New(isolate, value)) {}
+    Number(v8::Isolate* isolate, v8::Handle<v8::Value> value) :
+      Ref<v8::Number>(isolate, value.As<v8::Number>()) {}
+    Number(VALUE self) :
+      Ref<v8::Number>(self) {}
+
+    static void Init();
+  };
+
+  class Integer : public Ref<v8::Integer> {
+  public:
+    Integer(v8::Isolate* isolate, int32_t value) :
+      Ref<v8::Integer>(isolate, v8::Integer::New(isolate, value)) {}
+    Integer(v8::Isolate* isolate, uint32_t value) :
+      Ref<v8::Integer>(isolate, v8::Integer::NewFromUnsigned(isolate, value)) {}
+    Integer(VALUE self) :
+      Ref<v8::Integer>(self) {}
+  };
+
+  class Int32 : public Ref<v8::Int32> {
+  public:
+    Int32(VALUE self) :
+      Ref<v8::Int32>(self) {}
+    Int32(v8::Isolate* isolate, v8::Handle<v8::Value> value) :
+      Ref<v8::Int32>(isolate, value.As<v8::Int32>()) {}
+  };
+
+  class Uint32 : public Ref<v8::Uint32> {
+  public:
+    Uint32(VALUE self) :
+      Ref<v8::Uint32>(self) {}
+    Uint32(v8::Isolate* isolate, v8::Handle<v8::Value> value) :
+      Ref<v8::Uint32>(isolate, value.As<v8::Uint32>()) {}
+  };
+}
+
+
+#endif /* NUMBER_H */

--- a/ext/v8/object.cc
+++ b/ext/v8/object.cc
@@ -25,7 +25,7 @@ namespace rr {
     Locker lock(object.getIsolate());
 
     if (rb_obj_is_kind_of(key, rb_cNumeric)) {
-      return Bool(object->Set(UInt32(key), Value::rubyObjectToHandle(object.getIsolate(), value)));
+      return Bool(object->Set(Uint32_t(key), Value::rubyObjectToHandle(object.getIsolate(), value)));
     } else {
       return Bool(object->Set(*Value(key), Value::rubyObjectToHandle(object.getIsolate(), value)));
     }
@@ -36,7 +36,7 @@ namespace rr {
     Locker lock(object.getIsolate());
 
     if (rb_obj_is_kind_of(key, rb_cNumeric)) {
-      return Value::handleToRubyObject(object.getIsolate(), object->Get(UInt32(key)));
+      return Value::handleToRubyObject(object.getIsolate(), object->Get(Uint32_t(key)));
     } else {
       return Value::handleToRubyObject(object.getIsolate(), object->Get(*Value(key)));
     }

--- a/ext/v8/rr.h
+++ b/ext/v8/rr.h
@@ -37,6 +37,7 @@ inline VALUE not_implemented(const char* message) {
 #include "object.h"
 #include "array.h"
 #include "primitive.h"
+#include "number.h"
 #include "external.h"
 // This one is named v8_string to avoid name collisions with C's string.h
 #include "rr_string.h"

--- a/ext/v8/script-origin.cc
+++ b/ext/v8/script-origin.cc
@@ -1,7 +1,7 @@
 #include "rr.h"
 
 namespace rr {
-    VALUE ScriptOrigin::Class;
+  VALUE ScriptOrigin::Class;
   void ScriptOrigin::Init() {
     ClassBuilder("ScriptOrigin").
       defineSingletonMethod("new", &initialize).

--- a/ext/v8/uint32.h
+++ b/ext/v8/uint32.h
@@ -11,27 +11,27 @@ namespace rr {
    * Ruby VALUE is expected (such as a method call) E.g.
    *
    *   uint_32_t myInt = 5;
-   *   rb_funcall(UInt32(myInt), rb_intern("to_s")); //=> <String "5">
+   *   rb_funcall(Uint32_t(myInt), rb_intern("to_s")); //=> <String "5">
    *
    * It also converts a Ruby `VALUE` into its corresponding
    * `uint32_t`:
    *
-   *   uint_32_t myInt = UInt32(rb_eval_string("5")); //=> 5
+   *   uint_32_t myInt = Uint32_t(rb_eval_string("5")); //=> 5
    *
    * Like all `Equiv`s, it stores itself internally as a Ruby `VALUE`
    */
-  class UInt32 : public Equiv {
+  class Uint32_t : public Equiv {
   public:
     /**
-     * Construct a UInt32 from a Ruby `VALUE`
+     * Construct a Uint32_t from a Ruby `VALUE`
      */
-    UInt32(VALUE val) : Equiv(val) {}
+    Uint32_t(VALUE val) : Equiv(val) {}
 
     /**
-     * Construct a UInt32 from a `uint32_t` by converting it into its
+     * Construct a Uint32_t from a `uint32_t` by converting it into its
      * corresponding `VALUE`.
      */
-    UInt32(uint32_t ui) : Equiv(UINT2NUM(ui)) {}
+    Uint32_t(uint32_t ui) : Equiv(UINT2NUM(ui)) {}
 
     /**
      * Coerce the Ruby `VALUE` into a `uint32_t`.

--- a/ext/v8/uint32.h
+++ b/ext/v8/uint32.h
@@ -2,6 +2,10 @@
 #ifndef RR_UINT32
 #define RR_UINT32
 
+
+//TODO: remove this at some point. I don't see what this provides
+//above and beyond just using UINT2NUM and NUM2UINT.
+// --cowboyd Jul 9, 2015
 namespace rr {
 
   /**

--- a/ext/v8/value.cc
+++ b/ext/v8/value.cc
@@ -171,11 +171,15 @@ namespace rr {
     }
 
     if (handle->IsUint32()) {
-      return UInt32(handle->Uint32Value());
+      return Uint32(isolate, handle);
     }
 
     if (handle->IsInt32()) {
-      return INT2FIX(handle->Int32Value());
+      return Int32(isolate, handle);
+    }
+
+    if (handle->IsNumber()) {
+      return Number(isolate, handle);
     }
 
     if (handle->IsBoolean()) {
@@ -183,9 +187,6 @@ namespace rr {
     }
 
     // TODO
-    // if (handle->IsNumber()) {
-    //   return rb_float_new(handle->NumberValue());
-    // }
 
     if (handle->IsString()) {
       return String(isolate, handle->ToString());

--- a/spec/c/function_spec.rb
+++ b/spec/c/function_spec.rb
@@ -26,7 +26,7 @@ describe V8::C::Function do
 
     expect(@ctx.Global.Get(V8::C::String.NewFromUtf8(@isolate, 'one'))).to eq one
     expect(@ctx.Global.Get(V8::C::String.NewFromUtf8(@isolate, 'two'))).to eq two
-    expect(@ctx.Global.Get(V8::C::String.NewFromUtf8(@isolate, 'three'))).to eq 3
+    expect(@ctx.Global.Get(V8::C::String.NewFromUtf8(@isolate, 'three')).Value()).to eq 3
   end
 
   it 'can be called as a constructor' do

--- a/spec/c/number_spec.rb
+++ b/spec/c/number_spec.rb
@@ -1,0 +1,38 @@
+require 'c_spec_helper'
+
+describe "V8::C::Number pyramid" do
+  requires_v8_context
+
+  describe V8::C::Number do
+    let(:number) { V8::C::Number::New @isolate, 25.325 }
+    it "sees that value" do
+      expect(number.Value()).to eql 25.325
+    end
+    it "is a kind of primitive" do
+      expect(number).to be_kind_of V8::C::Primitive
+    end
+  end
+  describe V8::C::Integer do
+    let(:int) { V8::C::Integer::New @isolate, 5 }
+
+    it "is has a value of 5" do
+      expect(int.Value()).to eql 5
+    end
+
+    it "is a Uint32" do
+      expect(int.IsUint32()).to be_truthy
+      expect(int).to be_kind_of V8::C::Uint32
+    end
+  end
+  describe V8::C::Int32 do
+    let(:int32) { V8::C::Integer::New @isolate, -5 }
+
+    it "has a value of -5" do
+      expect(int32.Value()).to eql -5
+    end
+
+    it "is an Int32" do
+      expect(int32).to be_kind_of V8::C::Int32
+    end
+  end
+end

--- a/spec/c/value_spec.rb
+++ b/spec/c/value_spec.rb
@@ -23,7 +23,7 @@ describe V8::C::Value do
   end
 
   it 'converts FixNums' do
-    expect(convert(42)).to eq 42
+    expect(convert(42).Value()).to eq 42
   end
 
   it 'converts booleans' do


### PR DESCRIPTION
This implements the JavaScript types `Number`, `Int32`, and `Uint32`. Previously, I had been cheating and always using low-level ruby types everywhere and then converting them to their v8 equivalents at the last minute in the C code. Now that this properly wraps numeric types, If a method returns an `Int32`, then ruby will see it as a `V8::C::Int32` and not a `Fixnum` etc.. 

Not only does this represent the v8 API as faithfully in Ruby as possible, it also prevents the actual number values from being copied every single time they are passed from V8 to Ruby. Instead, there is just one copy in the V8 heap until it is deallocated.

Also, in this PR, I've experimented with using c++11 lambda pointers to implement the Ruby methods. I think that it makes the code a lot more readable, and it eliminates something like %25 of the boiler-plate. If this pans out, then it may be worth converting the whole codebase to this style.
